### PR TITLE
OpenOptions: add read+write case

### DIFF
--- a/src/shm.rs
+++ b/src/shm.rs
@@ -18,6 +18,9 @@ bitflags! {
         const READ = libc::O_RDONLY;
         /// Open for write.
         const WRITE = libc::O_WRONLY;
+        /// Open for read+write. Note that this is not the same value as `OpenOptions::READ |
+        /// OpenOptions::Write`.
+        const READWRITE = libc::O_RDWR;
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
weirdly, the bit values from libc (at least on my system, Debian/amd64) for `libc::O_RDONLY` (=0), `libc::O_WRONLY` (=1) and `libc::O_RDWR` (=2) make it so you can't get read-write by bit-or from read and write.

add the missing read+write as explicit bitflags value.